### PR TITLE
Fix warning in persistent movie phpt

### DIFF
--- a/tests/persistentMovie.phpt
+++ b/tests/persistentMovie.phpt
@@ -4,6 +4,7 @@ ffmpeg persistent movie test
 <?php extension_loaded('ffmpeg') or die("ffmpeg extension not loaded"); ?>
 --FILE--
 <?php
+ini_set('ffmpeg.allow_persistent', '1');
 $mov = new ffmpeg_movie(dirname(__FILE__) . '/test_media/robot.avi', 1);
 $mov2 = new ffmpeg_movie(dirname(__FILE__) . '/test_media/robot.avi', 1);
 printf("ffmpeg getDuration(): %0.2f\n", $mov->getDuration());


### PR DESCRIPTION
Set `ffmpeg.allow_persistent=1` to remove warning.
```
FAIL ffmpeg persistent movie test [tests/persistentMovie.phpt]
```
In `tests/persistentMovie.out`:
```
Warning: Persistent movies have been disabled in php.ini in /usr/src/ffmpeg-php/tests/persistentMovie.php on line 3

Warning: Persistent movies have been disabled in php.ini in /usr/src/ffmpeg-php/tests/persistentMovie.php on line 4
ffmpeg getDuration(): 9.64
ffmpeg getDuration(): 9.64
```

