### PR TITLE
Revert _php_get_ff_frame changes from #6

### DIFF
--- a/ffmpeg_movie.c
+++ b/ffmpeg_movie.c
@@ -1450,7 +1450,7 @@ static AVFrame* _php_read_av_frame(ff_movie_context *ffmovie_ctx,
     int video_stream;
     AVPacket packet;
     AVFrame *frame = NULL;
-    int got_frame, used;
+    int got_frame; 
 
     video_stream = _php_get_stream_index(ffmovie_ctx->fmt_ctx, 
             AVMEDIA_TYPE_VIDEO);
@@ -1469,24 +1469,7 @@ static AVFrame* _php_read_av_frame(ff_movie_context *ffmovie_ctx,
         if (packet.stream_index == video_stream) {
         
 #if LIBAVFORMAT_VERSION_INT > AV_VERSION_INT(52, 31, 0)
-#if 0
-     // FIXME: this function can crash with bad packets
-     used = avcodec_decode_video2(decoder_ctx, frame, &got_frame, &packet);
-#else
-         if (decoder_ctx->codec_type == AVMEDIA_TYPE_VIDEO ||
-             decoder_ctx->codec_type == AVMEDIA_TYPE_AUDIO) {
-             used = avcodec_send_packet(decoder_ctx, &packet);
-             if (used < 0 && used != AVERROR(EAGAIN) && used != AVERROR_EOF) {
-            } else {
-             if (used >= 0)
-                 packet.size = 0;
-             used = avcodec_receive_frame(decoder_ctx, frame);
-             if (used >= 0)
-                 got_frame = 1;
-             }
-         }
-#endif
-
+            avcodec_decode_video2(decoder_ctx, frame, &got_frame, &packet);
 #else
             avcodec_decode_video(decoder_ctx, frame, &got_frame,
                     packet.data, packet.size);

--- a/ffmpeg_movie.c
+++ b/ffmpeg_movie.c
@@ -1602,9 +1602,6 @@ static int _php_get_ff_frame(ff_movie_context *ffmovie_ctx,
     AVFrame *frame = NULL;
     ff_frame_context *ff_frame;
 
-    uint8_t *video_dst_data[4] = {NULL};
-    int video_dst_linesize[4];
- 
     frame = _php_get_av_frame(ffmovie_ctx, wanted_frame, &is_keyframe, &pts);
     if (frame) { 
         /*
@@ -1633,7 +1630,6 @@ static int _php_get_ff_frame(ff_movie_context *ffmovie_ctx,
 #endif
 
 
-#if 0
         avpicture_alloc((AVPicture*)ff_frame->av_frame, ff_frame->pixel_format,
             ff_frame->width, ff_frame->height);
 
@@ -1643,23 +1639,6 @@ static int _php_get_ff_frame(ff_movie_context *ffmovie_ctx,
         av_picture_copy((AVPicture*)ff_frame->av_frame, 
                         (AVPicture*)frame, ff_frame->pixel_format,
                 ff_frame->width, ff_frame->height);
-
-#else
-
-		int ret = av_image_alloc(ff_frame->av_frame->data,
-            ff_frame->av_frame->linesize, ff_frame->width, ff_frame->height,
-            ff_frame->pixel_format, 1);
-
-        if (ret < 0) {
-           memset(ff_frame->av_frame->data, 0, sizeof(AVPicture));
-        }
-
-        av_image_copy(video_dst_data, video_dst_linesize, 
-           (const uint8_t **)ff_frame->av_frame->data, ff_frame->av_frame->linesize,
-           ff_frame->pixel_format, ff_frame->width, ff_frame->height);
-
-#endif
- 
 
         return 1;
     } else {


### PR DESCRIPTION
This is not final solution, just proof of problem (or temporary workaround).
Changes in _php_get_ff_frame made in #6 caused problem with frame->toGDImage(). All images generated by tests was green and broken.
* Before revert:
![before-revert](https://user-images.githubusercontent.com/1571340/80259933-ff964800-8686-11ea-99ac-8857041ba424.png)
* After revert:
![after-revert](https://user-images.githubusercontent.com/1571340/80259940-058c2900-8687-11ea-93b2-8b004ee079a9.png)
Still first frames are bad. I am not sure if it is related to #6 changes or problem was before.

Compiled and tested on php7.4  with ffmpeg 4.2.2
```
ffmpeg version 4.2.2-1ubuntu1 Copyright (c) 2000-2019 the FFmpeg developers
  built with gcc 9 (Ubuntu 9.3.0-3ubuntu1)
  configuration: --prefix=/usr --extra-version=1ubuntu1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-nvenc --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared
  libavutil      56. 31.100 / 56. 31.100
  libavcodec     58. 54.100 / 58. 54.100
  libavformat    58. 29.100 / 58. 29.100
  libavdevice    58.  8.100 / 58.  8.100
  libavfilter     7. 57.100 /  7. 57.100
  libavresample   4.  0.  0 /  4.  0.  0
  libswscale      5.  5.100 /  5.  5.100
  libswresample   3.  5.100 /  3.  5.100
  libpostproc    55.  5.100 / 55.  5.100
```
and on php5.6 with ffmpeg 3.2.14
```
ffmpeg version 3.2.14-1~deb9u1 Copyright (c) 2000-2019 the FFmpeg developers
  built with gcc 6.3.0 (Debian 6.3.0-18+deb9u1) 20170516
  configuration: --prefix=/usr --extra-version='1~deb9u1' --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --enable-gpl --disable-stripping --enable-avresample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libebur128 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libmp3lame --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-omx --enable-openal --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libopencv --enable-libx264 --enable-shared
  libavutil      55. 34.101 / 55. 34.101
  libavcodec     57. 64.101 / 57. 64.101
  libavformat    57. 56.101 / 57. 56.101
  libavdevice    57.  1.100 / 57.  1.100
  libavfilter     6. 65.100 /  6. 65.100
  libavresample   3.  1.  0 /  3.  1.  0
  libswscale      4.  2.100 /  4.  2.100
  libswresample   2.  3.100 /  2.  3.100
  libpostproc    54.  1.100 / 54.  1.100
```
Edit: Revering changes in _php_read_av_frame fixes problem with first frames.
* After revert:
![after-revert-2](https://user-images.githubusercontent.com/1571340/80264970-40e22400-8696-11ea-9f51-02fafb686b34.png)
